### PR TITLE
[Noah] feat: dataStore 적용

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,4 +70,7 @@ dependencies {
     // hilt
     implementation "com.google.dagger:hilt-android:2.44"
     kapt "com.google.dagger:hilt-compiler:2.44"
+
+    // Preferences DataStore
+    implementation "androidx.datastore:datastore-preferences:1.0.0"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,6 +39,9 @@ android {
     kapt {
         correctErrorTypes true
     }
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
 }
 
 dependencies {
@@ -70,6 +73,23 @@ dependencies {
     // hilt
     implementation "com.google.dagger:hilt-android:2.44"
     kapt "com.google.dagger:hilt-compiler:2.44"
+
+    // hilt test
+    // For Robolectric tests.
+    testImplementation 'com.google.dagger:hilt-android-testing:2.44'
+    // ...with Kotlin.
+    kaptTest 'com.google.dagger:hilt-android-compiler:2.44'
+    // For instrumented tests.
+    androidTestImplementation 'com.google.dagger:hilt-android-testing:2.44'
+    // ...with Kotlin.
+    kaptAndroidTest 'com.google.dagger:hilt-android-compiler:2.44'
+
+    // mockito
+    androidTestImplementation 'org.mockito:mockito-android:4.0.0'
+    testImplementation 'org.mockito:mockito-inline:4.5.1'
+
+    // coroutine test
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4"
 
     // Preferences DataStore
     implementation "androidx.datastore:datastore-preferences:1.0.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -85,7 +85,7 @@ dependencies {
     kaptAndroidTest 'com.google.dagger:hilt-android-compiler:2.44'
 
     // mockito
-    androidTestImplementation 'org.mockito:mockito-android:4.0.0'
+    androidTestImplementation 'org.mockito:mockito-android:4.5.1'
     testImplementation 'org.mockito:mockito-inline:4.5.1'
 
     // coroutine test

--- a/app/src/main/java/com/survivalcoding/stopwatch/data/stopwatch/data_source/datastore/StopWatchStateDataStore.kt
+++ b/app/src/main/java/com/survivalcoding/stopwatch/data/stopwatch/data_source/datastore/StopWatchStateDataStore.kt
@@ -1,0 +1,9 @@
+package com.survivalcoding.stopwatch.data.stopwatch.data_source.datastore
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+
+
+val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "stopwatch_pref")

--- a/app/src/main/java/com/survivalcoding/stopwatch/data/stopwatch/repository/StopWatchStateRepositoryImpl.kt
+++ b/app/src/main/java/com/survivalcoding/stopwatch/data/stopwatch/repository/StopWatchStateRepositoryImpl.kt
@@ -1,0 +1,54 @@
+package com.survivalcoding.stopwatch.data.stopwatch.repository
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import com.survivalcoding.stopwatch.domain.stopwatch.repository.StopWatchStateRepository
+import com.survivalcoding.stopwatch.presentation.stopwatch.state.StopWatchState
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+
+class StopWatchStateRepositoryImpl(
+    private val dataStore: DataStore<Preferences>
+) : StopWatchStateRepository {
+    companion object {
+        val IS_PAUSED_KEY = booleanPreferencesKey("IS_PAUSED")
+        val IS_WORKING_KEY = booleanPreferencesKey("IS_WORKING")
+        val STANDARD_LAP_TIME_KEY = intPreferencesKey("STANDARD_LAP_TIME")
+        val START_LAP_TIME_KEY = intPreferencesKey("START_LAP_TIME")
+        val EXIT_TIME_KEY = intPreferencesKey("EXIT_TIME")
+    }
+
+    override suspend fun saveStopWatchState(stopWatchState: StopWatchState) {
+        dataStore.edit {
+            it[IS_PAUSED_KEY] = stopWatchState.isPaused
+            it[IS_WORKING_KEY] = stopWatchState.isWorking
+            it[STANDARD_LAP_TIME_KEY] = stopWatchState.standardLapTime
+            it[START_LAP_TIME_KEY] = stopWatchState.startLapTime
+            it[EXIT_TIME_KEY] = stopWatchState.exitTime
+        }
+    }
+
+    override fun isPausedFlow(): Flow<Boolean?> = dataStore.data.map {
+        it[IS_PAUSED_KEY]
+    }
+
+    override fun isWorkingFlow(): Flow<Boolean?> = dataStore.data.map {
+        it[IS_WORKING_KEY]
+    }
+
+    override fun standardLapTime(): Flow<Int?> = dataStore.data.map {
+        it[STANDARD_LAP_TIME_KEY]
+    }
+
+    override fun startLapTime(): Flow<Int?> = dataStore.data.map {
+        it[START_LAP_TIME_KEY]
+    }
+
+    override fun exitTime(): Flow<Int?> = dataStore.data.map {
+        it[EXIT_TIME_KEY]
+    }
+}

--- a/app/src/main/java/com/survivalcoding/stopwatch/di/AppModule.kt
+++ b/app/src/main/java/com/survivalcoding/stopwatch/di/AppModule.kt
@@ -1,10 +1,15 @@
 package com.survivalcoding.stopwatch.di
 
 import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
 import com.survivalcoding.stopwatch.data.stopwatch.data_source.dao.LapTimeRecordDao
 import com.survivalcoding.stopwatch.data.stopwatch.data_source.database.AppDatabase
+import com.survivalcoding.stopwatch.data.stopwatch.data_source.datastore.dataStore
 import com.survivalcoding.stopwatch.data.stopwatch.repository.LapTimeRepositoryImpl
+import com.survivalcoding.stopwatch.data.stopwatch.repository.StopWatchStateRepositoryImpl
 import com.survivalcoding.stopwatch.domain.stopwatch.repository.LapTimeRepository
+import com.survivalcoding.stopwatch.domain.stopwatch.repository.StopWatchStateRepository
 import com.survivalcoding.stopwatch.domain.stopwatch.use_case.DeleteAllLapTimesUseCase
 import com.survivalcoding.stopwatch.domain.stopwatch.use_case.DeleteLapTimeUseCase
 import com.survivalcoding.stopwatch.domain.stopwatch.use_case.GetLapTimesUseCase
@@ -16,7 +21,6 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
-
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -39,6 +43,18 @@ object AppModule {
     fun provideLapTimeRecordRepository(lapTimeRecordDao: LapTimeRecordDao): LapTimeRepository {
         return LapTimeRepositoryImpl(lapTimeRecordDao)
     }
+
+    @Provides
+    @Singleton
+    fun provideStopWatchStateDataStore(@ApplicationContext appContext: Context): DataStore<Preferences> =
+        appContext.dataStore
+
+    @Provides
+    @Singleton
+    fun provideStopWatchStateRepository(dataStore: DataStore<Preferences>): StopWatchStateRepository {
+        return StopWatchStateRepositoryImpl(dataStore)
+    }
+
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/survivalcoding/stopwatch/domain/stopwatch/repository/StopWatchStateRepository.kt
+++ b/app/src/main/java/com/survivalcoding/stopwatch/domain/stopwatch/repository/StopWatchStateRepository.kt
@@ -1,0 +1,19 @@
+package com.survivalcoding.stopwatch.domain.stopwatch.repository
+
+import com.survivalcoding.stopwatch.presentation.stopwatch.state.StopWatchState
+import kotlinx.coroutines.flow.Flow
+
+interface StopWatchStateRepository {
+
+    suspend fun saveStopWatchState(stopWatchState: StopWatchState)
+
+    fun isPausedFlow(): Flow<Boolean?>
+
+    fun isWorkingFlow(): Flow<Boolean?>
+
+    fun standardLapTime(): Flow<Int?>
+
+    fun startLapTime(): Flow<Int?>
+
+    fun exitTime(): Flow<Int?>
+}

--- a/app/src/main/java/com/survivalcoding/stopwatch/domain/stopwatch/use_case/GetStopWatchStateUseCase.kt
+++ b/app/src/main/java/com/survivalcoding/stopwatch/domain/stopwatch/use_case/GetStopWatchStateUseCase.kt
@@ -1,0 +1,17 @@
+package com.survivalcoding.stopwatch.domain.stopwatch.use_case
+
+import com.survivalcoding.stopwatch.domain.stopwatch.repository.StopWatchStateRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetStopWatchStateUseCase @Inject constructor(private val stopWatchStateRepository: StopWatchStateRepository) {
+    fun isPausedFlow(): Flow<Boolean?> = stopWatchStateRepository.isPausedFlow()
+
+    fun isWorkingFlow(): Flow<Boolean?> = stopWatchStateRepository.isWorkingFlow()
+
+    fun standardLapTime(): Flow<Int?> = stopWatchStateRepository.standardLapTime()
+
+    fun startLapTime(): Flow<Int?> = stopWatchStateRepository.startLapTime()
+
+    fun exitTime(): Flow<Int?> = stopWatchStateRepository.exitTime()
+}

--- a/app/src/main/java/com/survivalcoding/stopwatch/domain/stopwatch/use_case/SaveStopWatchStateUseCase.kt
+++ b/app/src/main/java/com/survivalcoding/stopwatch/domain/stopwatch/use_case/SaveStopWatchStateUseCase.kt
@@ -1,0 +1,10 @@
+package com.survivalcoding.stopwatch.domain.stopwatch.use_case
+
+import com.survivalcoding.stopwatch.domain.stopwatch.repository.StopWatchStateRepository
+import com.survivalcoding.stopwatch.presentation.stopwatch.state.StopWatchState
+import javax.inject.Inject
+
+class SaveStopWatchStateUseCase @Inject constructor(private val stopWatchStateRepository: StopWatchStateRepository) {
+    suspend operator fun invoke(stopWatchState: StopWatchState) =
+        stopWatchStateRepository.saveStopWatchState(stopWatchState)
+}

--- a/app/src/main/java/com/survivalcoding/stopwatch/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/survivalcoding/stopwatch/presentation/MainViewModel.kt
@@ -11,8 +11,10 @@ import javax.inject.Inject
 @HiltViewModel
 class MainViewModel @Inject constructor(
     private val application: Application,
-    savedState: SavedStateHandle
+    private val savedState: SavedStateHandle
 ) : ViewModel() {
+
+
     private val mPreferences: SharedPreferences =
         PreferenceManager.getDefaultSharedPreferences(application)
     private val editor: SharedPreferences.Editor = mPreferences.edit()

--- a/app/src/main/java/com/survivalcoding/stopwatch/presentation/stopwatch/StopWatchFragment.kt
+++ b/app/src/main/java/com/survivalcoding/stopwatch/presentation/stopwatch/StopWatchFragment.kt
@@ -71,7 +71,7 @@ class StopWatchFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         // 일시정지 시에 blink(깜빡임) 애니메이션 적용
-        recover(blinkAnim)
+        //recover(blinkAnim)
 
         // lapTime 가져오기
         lifecycleScope.launch {
@@ -105,6 +105,15 @@ class StopWatchFragment : Fragment() {
                     } else {
                         binding.progressiveTimerButton.progress = it.percent
                     }
+                }
+            }
+        }
+
+        // recover를 isWorking flow를 보고 작동하도록 설정
+        lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.isWorkingFlow().collect { isWorking ->
+                    recover(blinkAnim, isWorking ?: false)
                 }
             }
         }
@@ -191,8 +200,8 @@ class StopWatchFragment : Fragment() {
         _binding = null
     }
 
-    private fun recover(blinkAnim: Animation) {
-        if (viewModel.stopWatchState.isWorking) {
+    private fun recover(blinkAnim: Animation, isWorking: Boolean) {
+        if (isWorking) {
             viewModel.initTime()
             binding.resetButton.isVisible = true
             if (!viewModel.stopWatchState.isPaused) {
@@ -207,7 +216,5 @@ class StopWatchFragment : Fragment() {
                 binding.startPauseMotion?.transitionToStart()
             }
         }
-
-
     }
 }

--- a/app/src/main/java/com/survivalcoding/stopwatch/presentation/stopwatch/StopWatchViewModel.kt
+++ b/app/src/main/java/com/survivalcoding/stopwatch/presentation/stopwatch/StopWatchViewModel.kt
@@ -1,11 +1,11 @@
 package com.survivalcoding.stopwatch.presentation.stopwatch
 
 import android.app.Application
-import android.content.SharedPreferences
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.preference.PreferenceManager
 import com.survivalcoding.stopwatch.domain.stopwatch.model.LapTimeRecord
+import com.survivalcoding.stopwatch.domain.stopwatch.use_case.GetStopWatchStateUseCase
+import com.survivalcoding.stopwatch.domain.stopwatch.use_case.SaveStopWatchStateUseCase
 import com.survivalcoding.stopwatch.domain.stopwatch.use_case.bundle.LapTimeRecordUseCaseBundle
 import com.survivalcoding.stopwatch.presentation.stopwatch.state.MainUiState
 import com.survivalcoding.stopwatch.presentation.stopwatch.state.ProgressBarState
@@ -14,23 +14,18 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
 import java.util.*
 import javax.inject.Inject
 
 @HiltViewModel
 class StopWatchViewModel @Inject constructor(
-    private val application: Application,
-    private val lapTimeRecordUseCaseBundle: LapTimeRecordUseCaseBundle
+    application: Application,
+    private val lapTimeRecordUseCaseBundle: LapTimeRecordUseCaseBundle,
+    private val getStopWatchStateUseCase: GetStopWatchStateUseCase,
+    private val saveStopWatchStateUseCase: SaveStopWatchStateUseCase,
 ) : ViewModel() {
-    // SharedPreference
-    private val mPreferences: SharedPreferences =
-        PreferenceManager.getDefaultSharedPreferences(application)
-
-    private val editor: SharedPreferences.Editor = mPreferences.edit() // 에디터 객체 얻기
 
     private var time = 0
     private var timerWork: Timer? = null
@@ -46,23 +41,18 @@ class StopWatchViewModel @Inject constructor(
     val progressPercentState = _progressPercentState.asStateFlow()
 
     init {
-        val tempState =
-            mPreferences.getString(
-                "stopWatchState", Json.encodeToString(StopWatchState())
-            )?.let { Json.decodeFromString<StopWatchState>(it) }
-        if (tempState != null) {
+        viewModelScope.launch {
             _stopWatchState = stopWatchState.copy(
-                isPaused = tempState.isPaused,
-                isWorking = tempState.isWorking,
-                standardLapTime = tempState.standardLapTime,
-                startLapTime = tempState.startLapTime,
-                exitTime = tempState.exitTime
+                isPaused = getStopWatchStateUseCase.isPausedFlow().first() ?: true,
+                isWorking = getStopWatchStateUseCase.isWorkingFlow().first() ?: false,
+                standardLapTime = getStopWatchStateUseCase.startLapTime().first() ?: 0,
+                startLapTime = getStopWatchStateUseCase.startLapTime().first() ?: 0,
+                exitTime = getStopWatchStateUseCase.exitTime().first() ?: 0,
             )
             time = stopWatchState.exitTime
-        }
-
-        if (!stopWatchState.isPaused) {
-            stopWatchStart()
+            if (!stopWatchState.isPaused) {
+                stopWatchStart()
+            }
         }
     }
 
@@ -71,6 +61,9 @@ class StopWatchViewModel @Inject constructor(
             isWorking = isWorking
         )
     }
+
+    fun isWorkingFlow(): Flow<Boolean?> =
+        getStopWatchStateUseCase.isWorkingFlow()
 
     fun getLapTimeRecords(): Flow<List<LapTimeRecord>> =
         lapTimeRecordUseCaseBundle.getLapTimesUseCase()
@@ -166,7 +159,10 @@ class StopWatchViewModel @Inject constructor(
             exitTime = time
         )
         // 현재 기록 데이터 저장
-        editor.putString("stopWatchState", Json.encodeToString(stopWatchState))
-        editor.apply()
+//        editor.putString("stopWatchState", Json.encodeToString(stopWatchState))
+//        editor.apply()
+        viewModelScope.launch {
+            saveStopWatchStateUseCase(stopWatchState)
+        }
     }
 }

--- a/app/src/main/java/com/survivalcoding/stopwatch/presentation/stopwatch/StopWatchViewModel.kt
+++ b/app/src/main/java/com/survivalcoding/stopwatch/presentation/stopwatch/StopWatchViewModel.kt
@@ -45,7 +45,7 @@ class StopWatchViewModel @Inject constructor(
             _stopWatchState = stopWatchState.copy(
                 isPaused = getStopWatchStateUseCase.isPausedFlow().first() ?: true,
                 isWorking = getStopWatchStateUseCase.isWorkingFlow().first() ?: false,
-                standardLapTime = getStopWatchStateUseCase.startLapTime().first() ?: 0,
+                standardLapTime = getStopWatchStateUseCase.standardLapTime().first() ?: 0,
                 startLapTime = getStopWatchStateUseCase.startLapTime().first() ?: 0,
                 exitTime = getStopWatchStateUseCase.exitTime().first() ?: 0,
             )

--- a/app/src/test/java/com/survivalcoding/stopwatch/data/stopwatch/repository/LapTimeRepositoryImplTest.kt
+++ b/app/src/test/java/com/survivalcoding/stopwatch/data/stopwatch/repository/LapTimeRepositoryImplTest.kt
@@ -1,0 +1,107 @@
+package com.survivalcoding.stopwatch.data.stopwatch.repository
+
+import com.survivalcoding.stopwatch.data.stopwatch.data_source.dao.LapTimeRecordDao
+import com.survivalcoding.stopwatch.domain.stopwatch.model.LapTimeRecord
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.Mockito.*
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class LapTimeRepositoryImplTest {
+
+    @Mock
+    lateinit var lapTimeRecordDao: LapTimeRecordDao
+
+    @InjectMocks
+    lateinit var lapTimeRepositoryImpl: LapTimeRepositoryImpl
+
+    private fun <T> any(): T {
+        Mockito.any<T>()
+        return null as T
+    }
+
+
+    private var lapTimeRecords = arrayListOf<LapTimeRecord>(
+        LapTimeRecord(
+            0, 111, 111
+        ),
+        LapTimeRecord(
+            1, 222, 333
+        ),
+        LapTimeRecord(
+            2, 333, 666
+        )
+    )
+
+    @Before
+    fun setUp() {
+        // given
+        `when`(lapTimeRecordDao.getAll()).thenReturn(
+            flow {
+                emit(lapTimeRecords)
+            }
+        )
+    }
+
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `모든 랩타임 기록 가져오기`() = runTest {
+        val result = lapTimeRepositoryImpl.getLapTimes().first()
+        assertEquals(lapTimeRecords, result)
+    }
+
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `특정 랩타입 기록 삽입`() = runTest {
+        val lapTimeRecord: LapTimeRecord = LapTimeRecord(
+            elapsedTime = 999,
+            endTime = 999
+        )
+        `when`(lapTimeRecordDao.insert(any())).then {
+            lapTimeRecords.add(lapTimeRecord)
+        }
+        lapTimeRepositoryImpl.insertLapTime(lapTimeRecord)
+        verify(lapTimeRecordDao).insert(lapTimeRecord)
+        val result = lapTimeRepositoryImpl.getLapTimes().first()
+        assertEquals(lapTimeRecord, result[3])
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `특정 랩타입 기록 삭제`() = runTest {
+        val result = lapTimeRepositoryImpl.getLapTimes().first()
+        val beforeSize = result.size
+        val lapTimeRecord = result[2]
+        `when`(lapTimeRecordDao.delete(any())).then {
+            lapTimeRecords.remove(lapTimeRecord)
+        }
+        lapTimeRepositoryImpl.deleteLapTime(lapTimeRecord)
+        verify(lapTimeRecordDao).delete(lapTimeRecord)
+        val afterSize = lapTimeRepositoryImpl.getLapTimes().first().size
+        assertEquals(beforeSize - 1, afterSize)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `모든 랩타임 기록 삭제`() = runTest {
+        `when`(lapTimeRecordDao.deleteAll()).then {
+            lapTimeRecords.clear()
+        }
+        lapTimeRepositoryImpl.deleteAllLapTimes()
+        verify(lapTimeRecordDao).deleteAll()
+        val afterSize = lapTimeRepositoryImpl.getLapTimes().first().size
+        assertEquals(0, afterSize)
+    }
+}

--- a/app/src/test/java/com/survivalcoding/stopwatch/data/stopwatch/repository/StopWatchStateRepositoryImplTest.kt
+++ b/app/src/test/java/com/survivalcoding/stopwatch/data/stopwatch/repository/StopWatchStateRepositoryImplTest.kt
@@ -1,0 +1,110 @@
+package com.survivalcoding.stopwatch.data.stopwatch.repository
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.preferencesOf
+import com.survivalcoding.stopwatch.presentation.stopwatch.state.StopWatchState
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.Mockito.*
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class StopWatchStateRepositoryImplTest {
+
+    @Mock
+    private lateinit var dataStore: DataStore<Preferences>
+
+    private lateinit var stopWatchStateRepositoryImpl: StopWatchStateRepositoryImpl
+
+    private val stopWatchState = StopWatchState(
+        isPaused = true,
+        isWorking = false,
+        standardLapTime = 5000,
+        startLapTime = 1000,
+        exitTime = 3000
+    )
+
+    private val preferences = preferencesOf(
+        StopWatchStateRepositoryImpl.IS_PAUSED_KEY to stopWatchState.isPaused,
+        StopWatchStateRepositoryImpl.IS_WORKING_KEY to stopWatchState.isWorking,
+        StopWatchStateRepositoryImpl.START_LAP_TIME_KEY to stopWatchState.startLapTime,
+        StopWatchStateRepositoryImpl.STANDARD_LAP_TIME_KEY to stopWatchState.standardLapTime,
+        StopWatchStateRepositoryImpl.EXIT_TIME_KEY to stopWatchState.exitTime,
+    )
+
+    private fun <T> any(): T {
+        Mockito.any<T>()
+        return null as T
+    }
+
+    @Before
+    fun setUp() {
+        stopWatchStateRepositoryImpl = StopWatchStateRepositoryImpl(dataStore)
+        runBlocking {
+            `when`(dataStore.data).thenReturn(flowOf(preferences))
+            stopWatchStateRepositoryImpl.saveStopWatchState(stopWatchState)
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun saveStopWatchState() = runTest {
+//        `when`(dataStore.edit { any() }).then {
+//            val block = it.arguments[0] as (Preferences) -> Unit
+//            block(preferences)
+//        }
+        // TODO: 구현해야 함
+        //  * 어떠한 방법으로 edit을 mocking하여 테스트 해야 할 지 잘 모르겠음..
+        //  * verify(dataStore).edit {} 내부에 assert는 오류 남
+        //  * `when`(dataStore.edit { any() }).then 이용하여 건드려야 할 것 같으나, 참고 자료가 없다..
+        verify(dataStore).edit(any())
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `isPausedFlow는 DataStore로 부터 isPaused를 반환한다`() = runTest {
+        assertEquals(stopWatchState.isPaused, stopWatchStateRepositoryImpl.isPausedFlow().first())
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `isWorkingFlow는 DataStore로 부터 isWorking을 반환한다`() = runTest {
+        assertEquals(stopWatchState.isWorking, stopWatchStateRepositoryImpl.isWorkingFlow().first())
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `standardLapTime는 DataStore로 부터 standardLapTime을 반환한다`() = runTest {
+        assertEquals(
+            stopWatchState.standardLapTime,
+            stopWatchStateRepositoryImpl.standardLapTime().first()
+        )
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `startLapTime는 DataStore로 부터 startLapTime을 반환한다`() = runTest {
+        assertEquals(
+            stopWatchState.startLapTime,
+            stopWatchStateRepositoryImpl.startLapTime().first()
+        )
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `exitTime는 DataStore로 부터 exitTime는을 반환한다`() = runTest {
+        assertEquals(stopWatchState.exitTime, stopWatchStateRepositoryImpl.exitTime().first())
+    }
+}
+


### PR DESCRIPTION
<h2> feat: dataStore 적용 </h2>

- shared preferences를 data store로 변경
- data 단으로 분리, use case 적용
- viewmodel에서 data store 이용 및 flow 이용하며 상태 복구

<h2> 궁금한 점 </h2>

- data store를 적용하고, data 단으로 분리해보았는데, 구조를 이렇게 가져가는 게 맞는지 고민입니다.
- Hilt를 통해 data store 의존성을 주입해줬는데, 제가 작성한 코드대로 하면 될지, 더 나은 방법이 있을지 궁금합니다.
- viewmodel 의 init에서 상태를 복구해주는데, flow 형태의 데이터를 이러한 형태로 복구하는 것이 맞는 방법인지, 아니면 fun isWorkinFlow처럼 함수를 만들어 fragment에서 collect를 통해 모든 상태를 처리해주는 것이 맞을지 궁금합니다.